### PR TITLE
Add GMAIL integration to search for emails and load into Notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# GMAIL and Notion Integration
+
+This project integrates GMAIL and Notion to search for today's emails and load them into a Notion table.
+
+## Setup
+
+### GMAIL API Credentials
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a new project or select an existing project.
+3. Enable the GMAIL API for the project.
+4. Create OAuth 2.0 credentials.
+5. Download the `credentials.json` file and place it in the root directory of the project.
+
+### Notion API Credentials
+
+1. Go to the [Notion Integrations](https://www.notion.so/my-integrations) page.
+2. Create a new integration.
+3. Copy the integration token.
+4. Share the database with the integration.
+
+### Environment Variables
+
+Create a `.env` file in the root directory of the project and add the following environment variables:
+
+```
+NOTION_TOKEN=your_notion_integration_token
+NOTION_DATABASE_ID=your_notion_database_id
+NOTION_PAGE_ID=your_notion_page_id
+```
+
+## Running the Application
+
+1. Install the required dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+2. Run the Flask application:
+
+```
+python app/app.py
+```
+
+3. Use the `/load_emails_to_notion` endpoint to load today's emails into Notion.

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 from app.utils.notion_integration import add_to_notion_table
+from app.utils.gmail_integration import get_todays_emails
 
 app = Flask(__name__)
 
@@ -11,6 +12,22 @@ def add_to_notion():
     
     result = add_to_notion_table(data)
     return jsonify({"message": result})
+
+@app.route('/load_emails_to_notion', methods=['POST'])
+def load_emails_to_notion():
+    emails = get_todays_emails()
+    if not emails:
+        return jsonify({"error": "No emails found"}), 400
+    
+    for email in emails:
+        data = {
+            "Name": {"title": [{"text": {"content": email['subject']}}]},
+            "Description": {"rich_text": [{"text": {"content": email['body']}}]},
+            "Status": {"select": {"name": "To Do"}}
+        }
+        add_to_notion_table(data)
+    
+    return jsonify({"message": "Emails loaded to Notion successfully"})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib

--- a/app/utils/gmail_integration.py
+++ b/app/utils/gmail_integration.py
@@ -1,6 +1,81 @@
 import requests
+import os
+import datetime
+import base64
+import google.auth
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-def scrape_website_data(url):
-    BASE_URL = "https://r.jina.ai/"
-    response = requests.get(BASE_URL + url)
-    return response.text
+# If modifying these SCOPES, delete the file token.json.
+SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
+
+def authenticate_gmail():
+    """Shows basic usage of the Gmail API.
+    Lists the user's Gmail labels.
+    """
+    creds = None
+    # The file token.json stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    if os.path.exists('token.json'):
+        creds = Credentials.from_authorized_user_file('token.json', SCOPES)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server(port=0)
+        # Save the credentials for the next run
+        with open('token.json', 'w') as token:
+            token.write(creds.to_json())
+    return creds
+
+def search_emails(service, query):
+    try:
+        # Call the Gmail API
+        results = service.users().messages().list(userId='me', q=query).execute()
+        messages = results.get('messages', [])
+        return messages
+    except HttpError as error:
+        print(f'An error occurred: {error}')
+        return None
+
+def get_email_data(service, message_id):
+    try:
+        message = service.users().messages().get(userId='me', id=message_id).execute()
+        payload = message['payload']
+        headers = payload.get('headers', [])
+        subject = None
+        for header in headers:
+            if header['name'] == 'Subject':
+                subject = header['value']
+                break
+        parts = payload.get('parts', [])
+        body = None
+        for part in parts:
+            if part['mimeType'] == 'text/plain':
+                body = base64.urlsafe_b64decode(part['body']['data']).decode('utf-8')
+                break
+        return {'subject': subject, 'body': body}
+    except HttpError as error:
+        print(f'An error occurred: {error}')
+        return None
+
+def get_todays_emails():
+    creds = authenticate_gmail()
+    service = build('gmail', 'v1', credentials=creds)
+    today = datetime.date.today().strftime("%Y/%m/%d")
+    query = f'after:{today}'
+    messages = search_emails(service, query)
+    emails = []
+    if messages:
+        for message in messages:
+            email_data = get_email_data(service, message['id'])
+            if email_data:
+                emails.append(email_data)
+    return emails

--- a/app/utils/scraper.py
+++ b/app/utils/scraper.py
@@ -1,0 +1,6 @@
+import requests
+
+def scrape_website_data(url):
+    BASE_URL = "https://r.jina.ai/"
+    response = requests.get(BASE_URL + url)
+    return response.text


### PR DESCRIPTION
Add GMAIL integration to search for today's emails and load them into Notion.

* **GMAIL Integration:**
  - Add functions to authenticate with GMAIL API, search for today's emails, and extract relevant data from emails in `app/utils/gmail_integration.py`.
* **Flask App:**
  - Modify `app/app.py` to import GMAIL integration functions and add an endpoint to trigger GMAIL email search and load into Notion.
* **Dependencies:**
  - Update `app/requirements.txt` to include necessary libraries for GMAIL integration (`google-api-python-client`, `google-auth-httplib2`, `google-auth-oauthlib`).
* **Documentation:**
  - Update `README.md` to provide steps for setting up GMAIL API credentials, Notion API credentials, and required environment variables.
* **Scraper:**
  - Add a new file `app/utils/scraper.py` with a function to scrape data from a website.

