### PR TITLE
Create a flask server with endpoints for email data and social media post generation

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 CLIENTS_PATH_NAME=path/to/clients.json
 NOTION_API_KEY=your_notion_api_key
+GROQ_API_KEY=your_groq_api_key

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Create a `.env` file in the root directory of the project and add the following 
 NOTION_TOKEN=your_notion_integration_token
 NOTION_DATABASE_ID=your_notion_database_id
 NOTION_PAGE_ID=your_notion_page_id
+GROQ_API_KEY=your_groq_api_key
 ```
 
 ## Running the Application
@@ -44,3 +45,5 @@ python app/app.py
 ```
 
 3. Use the `/load_emails_to_notion` endpoint to load today's emails into Notion.
+
+4. Use the `/create_social_post` endpoint to create a social media post using GROQ LLaMA3 70B. Send a POST request with JSON data containing the `content` field to this endpoint. The response will contain the generated social media post.

--- a/app/app.py
+++ b/app/app.py
@@ -1,6 +1,8 @@
 from flask import Flask, request, jsonify
 from app.utils.notion_integration import add_to_notion_table, create_daily_read_page
 from app.utils.gmail_integration import get_todays_emails
+from app.utils.groq_llama3 import generate_social_post
+import os
 
 app = Flask(__name__)
 
@@ -31,6 +33,19 @@ def load_emails_to_notion():
         add_to_notion_table(data)
     
     return jsonify({"message": "Emails loaded to Notion successfully"})
+
+@app.route('/create_social_post', methods=['POST'])
+def create_social_post():
+    content = request.json.get('content')
+    if not content:
+        return jsonify({"error": "No content provided"}), 400
+    
+    api_key = os.getenv('GROQ_API_KEY')
+    if not api_key:
+        return jsonify({"error": "GROQ_API_KEY not found"}), 500
+    
+    social_post = generate_social_post(content, api_key)
+    return jsonify({"social_post": social_post})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/app/templates/notion_page.html
+++ b/app/templates/notion_page.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Notion Page</title>
+    <script>
+        async function createSocialPost() {
+            const content = document.getElementById('contentInput').value;
+            const response = await fetch('/create_social_post', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ content })
+            });
+            const data = await response.json();
+            document.getElementById('response').innerText = data.social_post;
+        }
+    </script>
+</head>
+<body>
+    <h1>Notion Page</h1>
+    <textarea id="contentInput" placeholder="Enter text here..."></textarea>
+    <button onclick="createSocialPost()">Create Social Post</button>
+    <p id="response"></p>
+</body>
+</html>

--- a/app/utils/groq_llama3.py
+++ b/app/utils/groq_llama3.py
@@ -1,0 +1,18 @@
+import requests
+import os
+
+def generate_social_post(content, api_key):
+    url = "https://api.groq.com/llama3/70b/generate"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json"
+    }
+    data = {
+        "prompt": content,
+        "max_tokens": 100
+    }
+    response = requests.post(url, headers=headers, json=data)
+    if response.status_code == 200:
+        return response.json().get("text")
+    else:
+        return None


### PR DESCRIPTION
Add a new endpoint to create social media posts using GROQ LLaMA3 70B.

* **New Endpoint**: Add `/create_social_post` endpoint in `app/app.py` to generate social media posts using GROQ LLaMA3 70B.
* **Environment Variable**: Update `.env` file to include `GROQ_API_KEY` for authentication.
* **Utility Function**: Create `app/utils/groq_llama3.py` to interact with the GROQ LLaMA3 70B API and generate social media posts.
* **Notion Page**: Add `app/templates/notion_page.html` with a button to accept text input, call the `/create_social_post` API, and display the response.
* **Documentation**: Update `README.md` to include setup instructions for `GROQ_API_KEY` and usage instructions for the new `/create_social_post` endpoint.

